### PR TITLE
Variable deceleration error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.DS_Store
 lib/.DS_Store
+.build*

--- a/lib/bootstrap3-wysihtml5.js
+++ b/lib/bootstrap3-wysihtml5.js
@@ -162,7 +162,7 @@
             options = $.extend(true, {}, options);
             options.toolbar = this.toolbar[0];
 
-            var editor = new wysi.Editor(this.el[0], options);
+            var editor = new wysihtml5.Editor(this.el[0], options);
 
             if(options && options.events) {
                 for(var eventName in options.events) {


### PR DESCRIPTION
Fixed invalid variable deceleration that was preventing editor from rendering and throwing the following error:  _Uncaught TypeError: Cannot read property 'Editor'_
